### PR TITLE
Restructure MHKiT developers section

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,22 +55,33 @@ MHKiT is open-source marine renewable energy (MRE) software, developed in Python
 
 Developers
 ================
-MHKiT is developed as a collaboration between the National Renewable Energy Laboratory (NREL), Pacific Northwest National Laboratory (PNNL), and Sandia National Laboratories (SNL). The core development team is listed below.  Additional contributors can be found on the
-`MHKiT-Python Contributors <https://github.com/MHKiT-Software/MHKiT-Python/graphs/contributors>`_ page and the
-`MHKiT-MATLAB Contributors <https://github.com/MHKiT-Software/MHKiT-MATLAB/graphs/contributors>`_ page.
+MHKiT is developed as a collaboration between the National Renewable Energy Laboratory (NREL), Pacific Northwest National Laboratory (PNNL), and Sandia National Laboratories (Sandia, SNL). 
+
+Current members of the core development team include:
 
 - Rebecca Fao (NREL - PI)
 - Sterling Olson (Sandia)
-- Matthew Boyd (NREL)
 - James McVey (PNNL)
 - Hristo Ivanov (NREL)
+- Carlos Michelen (Sandia)
+- Emily Browning (Sandia)
+- Adam Keester (Sandia)
+- Cesar Castillo (Sandia)
+- Budi Gunawan (Sandia - PI)
+
+Former members of the core development team include:
+
+- Matthew Boyd (NREL)
 - Alex McVey (NREL)
 - Katherine Klise (Sandia)
 - Kelley Ruehl (Sandia)
-- Carlos Michelen (Sandia)
-- Emily Browning (Sandia)
 - Frederick Driscoll (NREL)
-- Budi Gunawan (Sandia - PI)
+
+
+.. Note: here we could call out specific external (or lab-internal) staff that have contributed significantly
+MHKiT has had many additional contributors. An extensive list of contributors can be found on the
+`MHKiT-Python Contributors <https://github.com/MHKiT-Software/MHKiT-Python/graphs/contributors>`_ page and the
+`MHKiT-MATLAB Contributors <https://github.com/MHKiT-Software/MHKiT-MATLAB/graphs/contributors>`_ page.
 
 
 Funding


### PR DESCRIPTION
@rpauly18 @ssolson Thoughts on restructuring our developers section like this? I modeled this roughly off of WEC-Sim's [developer ](https://wec-sim.github.io/WEC-Sim/master/index.html#wec-sim-developers) and [acknowledgements ](https://wec-sim.github.io/WEC-Sim/master/introduction/acknowledgements.html#external-contributors) structure. 

I think this makes it easier for users to see who the current team consists of and it gives us a better place to call out specific external contributors who have added a lot. Let me know if this delineation needs further updating or if there are other external contributors you want to call out.