### PR TITLE
Fix examples and acoustics API

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cd docs
           rm -rf _build/*
-          make html
+          sphinx-build -b html source _build/html
           # Create .nojekyll file to prevent GitHub Pages from ignoring files that begin with an underscore
           touch _build/html/.nojekyll
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cd docs
           rm -rf _build/*
-          sphinx-build -b html source _build/html
+          make html
           # Create .nojekyll file to prevent GitHub Pages from ignoring files that begin with an underscore
           touch _build/html/.nojekyll
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           cd docs
           rm -rf _build/*
-        	cp ../MHKiT-Python/examples/* source/*
+          cp ../MHKiT-Python/examples/* source/
           sphinx-build -b html source _build/html
-	        cp ../MHKiT-MATLAB/examples/*.html ./_build/html/mhkit-matlab/ 
+          cp ../MHKiT-MATLAB/examples/*.html ./_build/html/mhkit-matlab 
           # Create .nojekyll file to prevent GitHub Pages from ignoring files that begin with an underscore
           touch _build/html/.nojekyll
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cd docs
           rm -rf _build/*
-          cp ../MHKiT-Python/examples/* source/
+          cp -r ../MHKiT-Python/examples/* source/
           sphinx-build -b html source _build/html
           cp ../MHKiT-MATLAB/examples/*.html ./_build/html/mhkit-matlab 
           # Create .nojekyll file to prevent GitHub Pages from ignoring files that begin with an underscore

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           cd docs
           rm -rf _build/*
+        	cp ../MHKiT-Python/examples/* source/*
           sphinx-build -b html source _build/html
+	        cp ../MHKiT-MATLAB/examples/*.html ./_build/html/mhkit-matlab/ 
           # Create .nojekyll file to prevent GitHub Pages from ignoring files that begin with an underscore
           touch _build/html/.nojekyll
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ docs/doctrees/
 .buildinfo.bak
 
 # IDE settings
-*/.vscode/*
+**/.vscode/**
 
 # Other
 issues.md

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = .
+BUILDDIR      = _build
 SOURCEDIR     = source
 
 # User-friendly check for sphinx-build
@@ -55,7 +55,7 @@ clean:
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)"
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html"
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -78,7 +78,7 @@ if "%1" == "html" (
 	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
 	if errorlevel 1 exit /b 1
 	echo.
-	Copy "..\MHKiT-MATLAB\examples\*.html" ".\mhkit-matlab\" 	
+	Copy "..\MHKiT-MATLAB\examples\*.html" ".\_build\html\mhkit-matlab\" 	
 	echo.Build finished. The HTML pages are in %BUILDDIR%/html
 	goto end
 )

--- a/docs/source/mhkit-python/api.acoustics.rst
+++ b/docs/source/mhkit-python/api.acoustics.rst
@@ -7,6 +7,8 @@ Passive Acoustics Module
     :members:
     :no-undoc-members:
     :show-inheritance:
+    :imported-members:
+    :exclude-members: VelBinner, epoch2dt64, dt642epoch
 
     .. automodule:: mhkit.acoustics.analysis
 


### PR DESCRIPTION
This PR makes a few fixes to the documentation:
- github Actions copies the example correctly. Currently they are not appearing, e.g. https://mhkit-software.github.io/MHKiT/river_example.ipynb and https://mhkit-software.github.io/MHKiT/mhkit-matlab/river_example.html
- fixes a minor formatting issue in the acoustics API
- fix minor path in .gitignore
- update `make.bat` and `Make` paths for consistent local builds